### PR TITLE
Fix images covering unsused space in feed posts

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -200,6 +200,12 @@ nav {
 .img-thumbnail{
     border-color: var(--bg-border-color);
     background-color: var(--bg-color) !important;
+    margin: 0 auto;
+    display: block;
+    object-fit: cover !important;
+    height: 100%;
+    width: 100%;
+    max-height: 200px;
 }
 
 .mobile_compt{


### PR DESCRIPTION
Fixed posts images on feed to cover all the space. Edited **.img-thumbnail** css class in **static/css/base.css** 
<img width="450" height="577" alt="Screenshot 2026-01-27 at 2 53 45 PM" src="https://github.com/user-attachments/assets/61c4c06e-4f2d-4f2f-90fd-da17fdd33500" />
