### PR TITLE
Fixed image and video dimensions in post details page

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -17,11 +17,12 @@ body{
 }
 
 .card { 
-    margin: 10px !important;
+    margin: 10px auto !important;
     padding: 10px !important;
     box-shadow: 5px 5px 10px var(--shadow-color-02) !important;
     background-color: var(--bg-color) !important;
     border-color: var(--button-border-color);
+    max-width: 600px;
 }
 
 div{
@@ -206,6 +207,23 @@ nav {
     height: 100%;
     width: 100%;
     max-height: 200px;
+}
+
+.img-container {
+    display: flex;
+    flex: row wrap;
+    justify-content: center;
+    align-items: flex-start;
+    /* max-width: 50% !important; */
+    /* width: 100%; */
+    margin: 0 auto;
+    aspect-ratio: 3.2;
+}
+
+.video-details {
+    width: 480px;
+    display: block;
+    margin: 0 auto;
 }
 
 .mobile_compt{

--- a/templates/post_templates/detail.html
+++ b/templates/post_templates/detail.html
@@ -4,7 +4,7 @@
 {% block body %}
 {% load timesince_shortner %}
     <div class="container"> 
-                <div class="card post_body_noscale d-inline-block" >
+                <div class="card post_body_noscale" >
                     <div class="caption">
                         <div style="position: relative; overflow: hidden; overflow-wrap: break-word;">
                             
@@ -18,15 +18,19 @@
                             </div>  
 
                             {% if post.video %}
-                                <video src="{{ post.video.url }}" alt="Post video" class="img-thumbnail mt-2" width="800" controls></video>                          
+                                <video src="{{ post.video.url }}" alt="Post video" class="video-details mt-2" width="500" controls></video>                          
                             {% endif %}
-
-                            {% if post.images.count %}
-                                {% for img in post.images.all %}
-                                    <img src="{{ img.image.url }}" alt="Post Image" class="img-thumbnail mt-2" style="width: 600px;">
-                                {% endfor %}
-                            {% elif post.image %}
-                                <img src="{{ post.image.url }}" alt="Post Image" class="img-thumbnail mt-2" style="width: 600px;">
+                            <!--Videos: If there's no image, don't show img-container-->
+                            {% if post.image %}
+                            <div class="img-container">
+                                {% if post.images.count %}
+                                    {% for img in post.images.all %}
+                                        <img src="{{ img.image.url }}" alt="Post Image" class="mt-2" style="width: 400px;">
+                                    {% endfor %}
+                                {% elif post.image %}
+                                    <img src="{{ post.image.url }}" alt="Post Image" class="mt-2" style="width: 400px;">
+                                {% endif %}
+                            </div>
                             {% endif %}
 
                             {% if has_html %}


### PR DESCRIPTION
Post Details Page: 

- Fixed image dimensions to show full image in normal size
- Fixed video dimensions to show full video in normal size
- Fixed post details width to make it look better and not as wide 

<img width="2870" height="2672" alt="Post-details" src="https://github.com/user-attachments/assets/855ed569-6b5f-4509-a51c-294e58119d34" />
