### PR TITLE
fix-header-profil-icon-mobile

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -3,10 +3,8 @@
 {% load static %}
 {% load profile_tag %}
 
-<nav class="navbar navbar-expand-lg" role="banner">
+<nav class="navbar navbar-expand-lg d-flex flex-row flex-nowrap" role="banner">
 
-    
-    
     <div class="container">
         
         <img id="home_boat" onclick="damage_boat()" src="{% static 'img/header/boat_sail_dmg0.png'%}" alt="Home">


### PR DESCRIPTION
Fixed profile pic for mobile devices: 
BEFORE: 
<img width="326" height="111" alt="Screenshot 2026-03-08 at 10 35 22 AM" src="https://github.com/user-attachments/assets/c4a95a9e-4044-4bf3-8ab4-a4787d1d36bd" />

AFTER: 
<img width="322" height="81" alt="Screenshot 2026-03-08 at 10 34 45 AM" src="https://github.com/user-attachments/assets/f9aee645-407a-401d-a080-6e9c9185458a" />

