### PR TITLE
Profile page UI optimization

### DIFF
--- a/templates/profile_templates/profile.html
+++ b/templates/profile_templates/profile.html
@@ -25,9 +25,47 @@
                 data-bs-toggle="modal" data-bs-target="#modal_1">Logout</a>
             </div>
 
+        <!------- PROFILE CARD AND STATS ------->
+        <div class="w-100 d-flex flex-column justify-content-evenly md-align-items-start flex-md-row flex-md-nowrap p-3 rounded mt-4" style="background-color:rgba(26, 25, 25, 0.7); " >
+
             {% include 'profile_templates/profile_user_card.html' %}
 
             <hr>
+
+            <!--START PROFILE STATS-->
+            <div class="flex-grow-1">
+                    <div class="col-md-0 ">
+                                                    
+                    <h3 style="text-align: center; ">Profile Stats</h3>
+                        <div class="d-flex">
+
+
+
+                            <div class="mt-1 w-100">
+                                <div class="row text-center flex-column justify-content-start">
+                                    <div class="col">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <small class="text_color">Profile Views</small>
+                                                <h4 class="text_color"><span>{{profile_views}}</span> / 1,000,000 </h4>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <small class="text_color">Posts Created</small>
+                                                <h4 class="text_color"><span>{{post_count}}</span> / 10,000</h4>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!--END PROFILE STATS-->
+            </div>
 
             <div class=" d-flex justify-content-between">
 
@@ -97,7 +135,7 @@
                 
                 <hr>
 
-                <div>
+                <!-- <div>
                     <div class="col-md-0">
                                                     
                     <h3 style="text-align: center;">Profile Stats</h3>
@@ -127,7 +165,7 @@
                             </div>
                         </div>
                     </div>
-                </div>
+                </div> -->
 
                     <!-- TODO: -->
                     <!-- will list the user stats like amount of likes, comments, posts, friends, bans, etc.-->

--- a/templates/profile_templates/profile_user_card.html
+++ b/templates/profile_templates/profile_user_card.html
@@ -1,16 +1,16 @@
 {% load static %}
 {% load profile_tag %}
-<div class="card">
+<div class="card flex-grow-1">
     <div class="col-md-0">
         
-        <div class="d-flex">
+        <div class="d-flex flex-column align-content-center justify-content-center align-items-center p-6">
             
         <!-- This is no longer used unless  you wana bring back custom profile pics -->
         <!-- {% if profile.image %}
             <img src="{{ profile.image.url }}" alt="profile image">
         {% else %} -->
         
-            <div class="2profile-box me-2" data-size="8">
+            <div class="2profile-box" data-size="8">
                 <div class="profile-box" data-size="8"> 
                     {% render_profile user %}
                 </div>
@@ -24,7 +24,7 @@
         
     
             <div>
-                <h1 class="ms-2">{{user}}</h1>
+                <h1 class="ms-2 text-center">{{user}}</h1>
                 <div class="d-flex justify-content-between">
 
                     <div class="ms-auto">
@@ -58,7 +58,7 @@
                             <p style="overflow-wrap: break-word; word-break: break-word;">{{ profile.bio }}</p>
                         </div>
                     {% else %}
-                        <h3 class="text_fadded">No Message</h3>
+                        <h3 class="text_fadded text-center">No Message</h3>
                     {% endif%}
 
                     {% if request.user == user %}
@@ -87,7 +87,7 @@
                 </div>
         </div>
 
-        <div class="d-flex justify-content-between">
+        <div class="d-flex flex-column justify-content-between align-items-center p-3">
             <small class="text_fadded">Edited: {{ profile.updated_at }}</small>
             <small class="text_fadded">Account Age: {{ profile.created_at}}</small>
         </div>

--- a/templates/profile_templates/profile_user_card.html
+++ b/templates/profile_templates/profile_user_card.html
@@ -3,13 +3,15 @@
 <div class="card flex-grow-1">
     <div class="col-md-0">
         
-        <div class="d-flex flex-column align-content-center justify-content-center align-items-center p-6">
+        <div class="d-flex flex-row flex-wrap flex-md-nowrap align-content-start justify-content-evenly align-items-start p-3 mb-3 gap-3">
             
         <!-- This is no longer used unless  you wana bring back custom profile pics -->
         <!-- {% if profile.image %}
             <img src="{{ profile.image.url }}" alt="profile image">
         {% else %} -->
         
+        <div class="d-flex flex-row flex-wrap flex-md-nowrap mb-3 gap-4">
+            <!--Profile img-->
             <div class="2profile-box" data-size="8">
                 <div class="profile-box" data-size="8"> 
                     {% render_profile user %}
@@ -21,16 +23,16 @@
             {% endif %}
 
         {% endif %}
-        
-    
+            <!--End of profile img-->
+        </div>
+        <div class="flex flex-column"> 
+            <!--Name and currency-->
             <div>
-                <h1 class="ms-2 text-center">{{user}}</h1>
-                <div class="d-flex justify-content-between">
-
-                    <div class="ms-auto">
+                <h1 class="ms-2 text-center text-md-start">{{user}}</h1>
+                <div class="d-flex justify-content-center justify-content-md-start">
 
                     {% if request.user == user %}
-                        <p class="ms-2 mb-0">Currency: {{ BZ }}</p> 
+                        <p class="ms-2 mb-0 text-center text-md-start">Currency: {{ BZ }}</p> 
                     {% endif %}
 
                     {% if profile.location %} <!-- Generic info about the account, you can put anything here -->
@@ -44,25 +46,24 @@
                     {% if profile.user_age %}
                         <p class="text_fadded mb-0 ms-2">Age: {{ profile.user_age}}</p>  <!-- Numeric value from 1-120 -->
                     {% endif %}
-
-                    </div>
                 </div>
 
             </div>
+            <!--End of name and currency-->
 
-            <hr class="ms-3" style="width: 4px; height: auto; display: inline-block; background-color: rgb(255, 255, 255);">
-
-                <div class="m-2 p-3">
+            <hr style="width: 100%; height: auto; display: inline-block; background-color: rgb(255, 255, 255);">
+            <!--Message & Reroll button-->
+                <div class="">
                     {% if profile.location %}
                         <div>
                             <p style="overflow-wrap: break-word; word-break: break-word;">{{ profile.bio }}</p>
                         </div>
                     {% else %}
-                        <h3 class="text_fadded text-center">No Message</h3>
+                        <h3 class="text_fadded text-center text-md-start mb-3">No Message</h3>
                     {% endif%}
 
                     {% if request.user == user %}
-                        <a href="{% url 'procedural_pfp:pfp_reroll' %}" class="btn btn-primary button_shadow m-2">
+                        <a href="{% url 'procedural_pfp:pfp_reroll' %}" class="btn btn-primary button_shadow ">
                             <img class="refresh" alt="Reroll profile"> Reroll Profile -20 BZ
                         </a>
                     {% endif %}
@@ -85,8 +86,12 @@
                         {% endif %}
                     {% endif %}
                 </div>
+                <!--End of message & reroll-->
         </div>
 
+    </div>
+
+        <!--Edited and account age dates-->
         <div class="d-flex flex-column justify-content-between align-items-center p-3">
             <small class="text_fadded">Edited: {{ profile.updated_at }}</small>
             <small class="text_fadded">Account Age: {{ profile.created_at}}</small>


### PR DESCRIPTION
Fixes #229 

Improved profile page UI by grouping the profile card with the stats, showing better hierarchy of components. 

**BEFORE:** 
<img width="2880" height="2954" alt="Profile-page" src="https://github.com/user-attachments/assets/73e4d0e6-c68f-4d45-819e-c85af0680e65" />

**AFTER:** 
<img width="2880" height="3390" alt="Updated-Profile-page" src="https://github.com/user-attachments/assets/f5bb75db-4e28-45e1-b96f-cf25e753f5a1" />
